### PR TITLE
Use generics to infer return type

### DIFF
--- a/core/block_dragger.js
+++ b/core/block_dragger.js
@@ -43,7 +43,8 @@ Blockly.BlockDragger = function(block, workspace) {
    */
   this.workspace_ = workspace;
 
-  var connectionManagerClass = Blockly.registry.getClassFromOptions(workspace.options, 'connectionManager');
+  var connectionManagerClass = Blockly.registry.getClassFromOptions(
+      workspace.options, Blockly.registry.Type.CONNECTION_MANAGER);
 
   /**
    * Object that keeps track of connections on dragged blocks.

--- a/core/field_registry.js
+++ b/core/field_registry.js
@@ -51,7 +51,8 @@ Blockly.fieldRegistry.unregister = function(type) {
  * @package
  */
 Blockly.fieldRegistry.fromJson = function(options) {
-  var fieldClass = Blockly.registry.getClass('field', options['type']);
+  var fieldClass = /** @type {{fromJson:function(!Object):!Blockly.Field}} */ (
+    Blockly.registry.getClass(Blockly.registry.Type.FIELD, options['type']));
   if (!fieldClass) {
     console.warn('Blockly could not create a field of type ' + options['type'] +
       '. The field is probably not being registered. This could be because' +

--- a/core/registry.js
+++ b/core/registry.js
@@ -12,6 +12,38 @@
 
 goog.provide('Blockly.registry');
 
+/**
+ * A name with the type of the element stored in the generic.
+ * @param {string} name The name of the registry type.
+ * @constructor
+ * @template T
+ */
+Blockly.registry.Type = function(name) {
+  /** @private {string} */
+  this.name_ = name;
+};
+
+/**
+ * Returns the name.
+ * @return {string} The name.
+ * @override
+ */
+Blockly.registry.Type.prototype.toString = function() {
+  return this.name_;
+};
+
+/** @type {!Blockly.registry.Type<Blockly.blockRendering.Renderer>} */
+Blockly.registry.Type.RENDERER = new Blockly.registry.Type('renderer');
+
+/** @type {!Blockly.registry.Type<Blockly.Field>} */
+Blockly.registry.Type.FIELD = new Blockly.registry.Type('field');
+
+/** @type {!Blockly.registry.Type<Blockly.IToolbox>} */
+Blockly.registry.Type.TOOLBOX = new Blockly.registry.Type('toolbox');
+
+/** @type {!Blockly.registry.Type<Blockly.InsertionMarkerManager>} */
+Blockly.registry.Type.CONNECTION_MANAGER =
+  new Blockly.registry.Type('connectionManager');
 
 Blockly.registry.typeMap_ = {};
 
@@ -74,12 +106,15 @@ Blockly.registry.unregister = function(type, name) {
 
 /**
  * Get the class for the given name and type.
- * @param {string} type The type of the plugin. (Ex: Field, Toolbox)
+ * @param {string|Blockly.registry.Type<T>} type The type of the plugin.
+ *     (eg: Field, Toolbox)
  * @param {string} name The name of the plugin. (Ex: field_angle)
- * @return {Object} The class with the given name and type or null if none exists.
+ * @return {?function(new:T, ...?)} The class with the given name and type or
+ *     null if none exists.
+ * @template T
  */
 Blockly.registry.getClass = function(type, name) {
-  type = type.toLowerCase();
+  type = String(type).toLowerCase();
   name = name.toLowerCase();
   var typeRegistry = Blockly.registry.typeMap_[type];
   if (!typeRegistry) {
@@ -96,8 +131,10 @@ Blockly.registry.getClass = function(type, name) {
 /**
  * Used for all plugins that have a built in option.
  * @param {!Blockly.Options} options The set of options for a given workspace.
- * @param {string} type The type of the plugin.
- * @return {Object} The class for the plugin.
+ * @param {string|Blockly.registry.Type<T>} type The type of the plugin.
+ * @return {?function(new:T, ...?)} The class with the given name and type or
+ *     null if none exists.
+ * @template T
  * @package
  */
 Blockly.registry.getClassFromOptions = function(options, type) {

--- a/core/renderers/common/block_rendering.js
+++ b/core/renderers/common/block_rendering.js
@@ -78,9 +78,9 @@ Blockly.blockRendering.stopDebugger = function() {
  * @package
  */
 Blockly.blockRendering.init = function(name, theme, opt_rendererOverrides) {
-  var rendererClass = Blockly.registry.getClass('renderer', name);
-  var renderer = (/** @type {!Blockly.blockRendering.Renderer} */ (
-    new rendererClass(name)));
+  var rendererClass =
+    Blockly.registry.getClass(Blockly.registry.Type.RENDERER, name);
+  var renderer = new rendererClass(name);
   renderer.init(theme, opt_rendererOverrides);
   return renderer;
 };

--- a/core/workspace_svg.js
+++ b/core/workspace_svg.js
@@ -339,7 +339,7 @@ Blockly.WorkspaceSvg.prototype.flyout_ = null;
 /**
  * Category-based toolbox providing blocks which may be dragged into this
  * workspace.
- * @type {Blockly.Toolbox}
+ * @type {Blockly.IToolbox}
  * @private
  */
 Blockly.WorkspaceSvg.prototype.toolbox_ = null;
@@ -462,7 +462,7 @@ Blockly.WorkspaceSvg.prototype.setMarkerSvg = function(markerSvg) {
  * Add a plugin to the list of plugins for this workspace. If it is of certain
  * types then add it to all lists that it applies to.
  * @param {string} type The type of the plugin.
- * @param {Object} pluginClass The constructor for a plugin.
+ * @param {Function} pluginClass The constructor for a plugin.
  * @param {Object} params The other params for the plugin.
  */
 Blockly.WorkspaceSvg.prototype.addPlugin = function(type, pluginClass, params) {
@@ -763,8 +763,9 @@ Blockly.WorkspaceSvg.prototype.createDom = function(opt_backgroundClass) {
   // Determine if there needs to be a category tree, or a simple list of
   // blocks.  This cannot be changed later, since the UI is very different.
   if (this.options.hasCategories) {
-    var toolboxClass = Blockly.registry.getClassFromOptions(this.options, 'toolbox');
-    this.toolbox_ = /** @type {!Blockly.IToolbox} */ (new toolboxClass(this));
+    var toolboxClass = Blockly.registry.getClassFromOptions(this.options,
+        Blockly.registry.Type.TOOLBOX);
+    this.toolbox_ = new toolboxClass(this);
   }
   if (this.grid_) {
     this.grid_.update(this.scale);
@@ -1212,7 +1213,7 @@ Blockly.WorkspaceSvg.prototype.setVisible = function(isVisible) {
   this.getParentSvg().style.display = isVisible ? 'block' : 'none';
   if (this.toolbox_) {
     // Currently does not support toolboxes in mutators.
-    this.toolbox_.HtmlDiv.style.display = isVisible ? 'block' : 'none';
+    (/** @type {?} */ (this.toolbox_)).HtmlDiv.style.display = isVisible ? 'block' : 'none';
   }
   var uiPlugins = this.plugins['uiplugin'];
   for (var i = 0; uiPlugins && i < uiPlugins.length; i++) {
@@ -2264,7 +2265,7 @@ Blockly.WorkspaceSvg.prototype.scroll = function(x, y) {
 
 /**
  * Get the dimensions of the given workspace component, in pixels.
- * @param {Blockly.Toolbox|Blockly.Flyout} elem The element to get the
+ * @param {Blockly.IToolbox|Blockly.Flyout} elem The element to get the
  *     dimensions of, or null.  It should be a toolbox or flyout, and should
  *     implement getWidth() and getHeight().
  * @return {!Object} An object containing width and height attributes, which


### PR DESCRIPTION
Demonstrating how to use generics to infer return type of `getClass` / `getClassFromOptions`.

Notice how we don't need to cast the type returned if we pass in the type: `Blockly.registry.Type`.